### PR TITLE
Use fragment / hash for source.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## unreleased
+
+* Playground: Use URL fragment/hash instead of query params to store source.
+
+
 ## 0.6.0 (2024-06-09)
 
 * SVGs copied now use `&#160;` for spaces for valid SVG XML.

--- a/playground/Cargo.toml
+++ b/playground/Cargo.toml
@@ -38,7 +38,8 @@ lz-str = "0.2.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { workspace = true }
-web-sys = { workspace = true, features = ["Document", "Element", "HtmlElement", "Url", "UrlSearchParams", "Window"] }
+web-sys = { workspace = true, features = ["console", "Document", "Element", "HtmlElement", "Url", "UrlSearchParams", "Window"] }
+js-sys = { workspace = true }
 
 [features]
 hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]

--- a/playground/src/app.rs
+++ b/playground/src/app.rs
@@ -19,14 +19,30 @@ const QUERY_PARAM_DIAGRAM_ONLY: &str = "diagram_only";
 /// `create_effect` is safe.
 #[cfg(target_arch = "wasm32")]
 fn diagram_only_init(set_diagram_only: WriteSignal<bool>) {
-    use web_sys::Url;
+    use js_sys::Array;
+    use web_sys::{console, Url, UrlSearchParams};
 
     create_effect(move |_| {
-        if let Some(url_search_params) = web_sys::window().map(|window| {
-            Url::new(&String::from(window.location().to_string()))
-                .expect("Expected URL to be valid.")
-                .search_params()
-        }) {
+        let url_search_params = web_sys::window().and_then(|window| {
+            let url = Url::new(&String::from(window.location().to_string()))
+                .expect("Expected URL to be valid.");
+
+            let hash = url.hash();
+            if hash.is_empty() {
+                Some(url.search_params())
+            } else {
+                match UrlSearchParams::new_with_str(hash.as_str()) {
+                    Ok(search_params) => Some(search_params),
+                    Err(error) => {
+                        let message = Array::new_with_length(1);
+                        message.set(0, error);
+                        console::log(&message);
+                        None
+                    }
+                }
+            }
+        });
+        if let Some(url_search_params) = url_search_params {
             let diagram_only = url_search_params
                 .get(QUERY_PARAM_DIAGRAM_ONLY)
                 .and_then(|diagram_only_str| serde_yaml::from_str::<bool>(&diagram_only_str).ok())

--- a/playground/src/app/info_graph.rs
+++ b/playground/src/app/info_graph.rs
@@ -23,47 +23,67 @@ const QUERY_PARAM_SRC: &str = "src";
 #[cfg(target_arch = "wasm32")]
 fn info_graph_src_init(set_info_graph_src: WriteSignal<String>) {
     use lz_str::decompress_from_encoded_uri_component;
-    use web_sys::{Document, Url};
+    use web_sys::{console, Document, Url, UrlSearchParams};
+    use js_sys::Array;
 
     create_effect(move |_| {
         if let Some(window) = web_sys::window() {
-            let url_search_params = Url::new(&String::from(window.location().to_string()))
-                .expect("Expected URL to be valid.")
-                .search_params();
-            let info_graph_src_initial = url_search_params
-                .get(QUERY_PARAM_SRC)
-                .map(|src| {
-                    if src.contains("\n") {
-                        // Treat src as plain yaml
-                        src
-                    } else {
-                        // Try deserialize/serialize src as lz_str
-                        decompress_from_encoded_uri_component(&src).map_or_else(
-                            || format!("# deserialize src error: invalid data"),
-                            |s| {
-                                String::from_utf16(&s).unwrap_or_else(|_| {
-                                    format!("# deserialize src error: invalid data")
-                                })
-                            },
-                        )
+            let url_search_params = {
+                let url = Url::new(&String::from(window.location().to_string()))
+                    .expect("Expected URL to be valid.");
+
+                let hash = url.hash();
+                if hash.is_empty() {
+                    Some(url.search_params())
+                } else {
+                    match UrlSearchParams::new_with_str(hash.as_str()) {
+                        Ok(search_params) => Some(search_params),
+                        Err(error) => {
+                            let message = Array::new_with_length(1);
+                            message.set(0, error);
+                            console::log(&message);
+                            None
+                        }
                     }
-                })
-                .unwrap_or_else(|| String::from(INFO_GRAPH_DEMO));
+                }
+            };
 
-            set_info_graph_src.set(info_graph_src_initial);
+            if let Some(url_search_params) = url_search_params {
+                let info_graph_src_initial = url_search_params
+                    .get(QUERY_PARAM_SRC)
+                    .map(|src| {
+                        if src.contains("\n") {
+                            // Treat src as plain yaml
+                            src
+                        } else {
+                            // Try deserialize/serialize src as lz_str
+                            decompress_from_encoded_uri_component(&src).map_or_else(
+                                || format!("# deserialize src error: invalid data"),
+                                |s| {
+                                    String::from_utf16(&s).unwrap_or_else(|_| {
+                                        format!("# deserialize src error: invalid data")
+                                    })
+                                },
+                            )
+                        }
+                    })
+                    .unwrap_or_else(|| String::from(INFO_GRAPH_DEMO));
 
-            // Hack: Get Tailwind CSS from CDN to reevaluate document.
-            set_timeout(
-                move || {
-                    let _ = window
-                        .document()
-                        .as_ref()
-                        .and_then(Document::body)
-                        .as_deref()
-                        .map(|element| element.append_with_str_1(""));
-                },
-                Duration::from_millis(200),
-            );
+                set_info_graph_src.set(info_graph_src_initial);
+
+                // Hack: Get Tailwind CSS from CDN to reevaluate document.
+                set_timeout(
+                    move || {
+                        let _ = window
+                            .document()
+                            .as_ref()
+                            .and_then(Document::body)
+                            .as_deref()
+                            .map(|element| element.append_with_str_1(""));
+                    },
+                    Duration::from_millis(200),
+                );
+            }
         } else {
             set_info_graph_src.set(String::from("# Could not extract search params."));
         }


### PR DESCRIPTION
Allows us to have larger diagrams without hitting the server request size limit.

Also avoids sending data to the server (modern browsers don't send the fragment).