### PR TITLE
Add more `ThemeAttr`s, and inform user when not all stroke / outline / fill class partials are provided.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,16 @@
 * Take in `tags` which only include tag names.
 * Take in `tag_items` for nodes and edges instead of tags per node.
 * Support theming nodes based on tag focus.
+* Add `ThemeAttr::Animate` to support setting [`animation`].
+* Add `ThemeAttr::Visibility` to support setting [`visibility`].
+* Fix black outline shown on focused nodes in Chrome / Edge.
+* Show feedback to user when stroke / outline / fill class partials are not all specified.
 
 [monaco]: https://github.com/microsoft/monaco-editor
 [rust-monaco]: https://github.com/siku2/rust-monaco
 [cursor styling]: https://tailwindcss.com/docs/cursor
+[`animation`]: https://tailwindcss.com/docs/animation
+[`visibility`]: https://tailwindcss.com/docs/visibility
 
 
 ## 0.7.0 (2024-06-30)

--- a/crate/model/src/common/dot_src_and_styles.rs
+++ b/crate/model/src/common/dot_src_and_styles.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::theme::ThemeWarnings;
+
 /// Graphviz dot source and CSS styles.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DotSrcAndStyles {
@@ -7,4 +9,32 @@ pub struct DotSrcAndStyles {
     pub dot_src: String,
     /// Tailwind CSS styles to put into `<styles>..</styles>`.
     pub styles: String,
+    /// Warnings detected while computing CSS utility classes.
+    pub theme_warnings: ThemeWarnings,
+}
+
+impl DotSrcAndStyles {
+    /// Returns a new `DotSrcAndStyles` object.
+    pub fn new(dot_src: String, styles: String, theme_warnings: ThemeWarnings) -> Self {
+        Self {
+            dot_src,
+            styles,
+            theme_warnings,
+        }
+    }
+
+    /// Returns the Graphviz dot source to run in `dot`.
+    pub fn dot_src(&self) -> &str {
+        &self.dot_src
+    }
+
+    /// Returns the tailwind CSS styles to put into `<styles>..</styles>`.
+    pub fn styles(&self) -> &str {
+        &self.styles
+    }
+
+    /// Returns the warnings detected while computing CSS utility classes.
+    pub fn theme_warnings(&self) -> &ThemeWarnings {
+        &self.theme_warnings
+    }
 }

--- a/crate/model/src/theme/css_class_merger.rs
+++ b/crate/model/src/theme/css_class_merger.rs
@@ -118,6 +118,7 @@ impl CssClassMerger {
             });
         });
 
+        Self::animation_classes(&mut css_classes_builder, defaults, specified);
         Self::visibility_classes(&mut css_classes_builder, defaults, specified);
         Self::cursor_classes(&mut css_classes_builder, defaults, specified);
         Self::extra_classes(&mut css_classes_builder, defaults, specified);
@@ -215,6 +216,7 @@ impl CssClassMerger {
             themeable,
         );
 
+        Self::animation_classes(&mut css_classes_builder, defaults, specified);
         Self::visibility_classes(&mut css_classes_builder, defaults, specified);
         Self::cursor_classes(&mut css_classes_builder, defaults, specified);
         Self::extra_classes(&mut css_classes_builder, defaults, specified);
@@ -527,6 +529,17 @@ impl CssClassMerger {
             }
             (color, shade) => FillClassAppendResult::NoChange { color, shade },
         }
+    }
+
+    fn animation_classes(
+        css_classes_builder: &mut CssClassesBuilder,
+        defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
+    ) {
+        specified
+            .and_then(|partials| partials.get(&ThemeAttr::Animate))
+            .or_else(|| defaults.and_then(|partials| partials.get(&ThemeAttr::Animate)))
+            .map(|visibility| css_classes_builder.append(&format!("animate-{visibility}")));
     }
 
     fn visibility_classes(

--- a/crate/model/src/theme/css_class_merger.rs
+++ b/crate/model/src/theme/css_class_merger.rs
@@ -118,6 +118,7 @@ impl CssClassMerger {
             });
         });
 
+        Self::visibility_classes(&mut css_classes_builder, defaults, specified);
         Self::cursor_classes(&mut css_classes_builder, defaults, specified);
         Self::extra_classes(&mut css_classes_builder, defaults, specified);
 
@@ -214,6 +215,7 @@ impl CssClassMerger {
             themeable,
         );
 
+        Self::visibility_classes(&mut css_classes_builder, defaults, specified);
         Self::cursor_classes(&mut css_classes_builder, defaults, specified);
         Self::extra_classes(&mut css_classes_builder, defaults, specified);
 
@@ -525,6 +527,17 @@ impl CssClassMerger {
             }
             (color, shade) => FillClassAppendResult::NoChange { color, shade },
         }
+    }
+
+    fn visibility_classes(
+        css_classes_builder: &mut CssClassesBuilder,
+        defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
+    ) {
+        specified
+            .and_then(|partials| partials.get(&ThemeAttr::Visibility))
+            .or_else(|| defaults.and_then(|partials| partials.get(&ThemeAttr::Visibility)))
+            .map(|visibility| css_classes_builder.append(visibility));
     }
 
     fn cursor_classes(

--- a/crate/model/src/theme/css_class_merger.rs
+++ b/crate/model/src/theme/css_class_merger.rs
@@ -77,24 +77,24 @@ impl CssClassMerger {
             &mut css_classes_builder,
             &mut warnings,
             themeable_node_outline_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
         Self::stroke_classes_append(
             &mut css_classes_builder,
             &mut warnings,
             themeable_node_stroke_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
         Self::fill_classes_append(
             &mut css_classes_builder,
             &mut warnings,
             themeable_node_fill_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
 
@@ -111,14 +111,14 @@ impl CssClassMerger {
                 spacing_keys,
             } = css_classes_param_groupings;
 
-            let spacing = attr_value_find(spacing_keys, specified, defaults);
+            let spacing = attr_value_find(spacing_keys, defaults, specified);
 
             spacing
                 .map(|spacing| css_classes_builder.append(&format!("{spacing_prefix}-{spacing}")));
         });
 
-        Self::cursor_classes(specified, defaults, &mut css_classes_builder);
-        Self::extra_classes(specified, defaults, &mut css_classes_builder);
+        Self::cursor_classes(defaults, specified, &mut css_classes_builder);
+        Self::extra_classes(defaults, specified, &mut css_classes_builder);
 
         let css_classes = css_classes_builder.build();
 
@@ -192,29 +192,29 @@ impl CssClassMerger {
             &mut css_classes_builder,
             &mut warnings,
             themeable_edge_outline_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
         Self::stroke_classes_append(
             &mut css_classes_builder,
             &mut warnings,
             themeable_edge_stroke_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
         Self::fill_classes_append(
             &mut css_classes_builder,
             &mut warnings,
             themeable_edge_fill_classes,
-            specified,
             defaults,
+            specified,
             themeable,
         );
 
-        Self::cursor_classes(specified, defaults, &mut css_classes_builder);
-        Self::extra_classes(specified, defaults, &mut css_classes_builder);
+        Self::cursor_classes(defaults, specified, &mut css_classes_builder);
+        Self::extra_classes(defaults, specified, &mut css_classes_builder);
 
         let css_classes = css_classes_builder.build();
 
@@ -225,8 +225,8 @@ impl CssClassMerger {
         css_classes_builder: &mut CssClassesBuilder,
         warnings: &mut ThemeWarnings,
         fn_outline_classes: fn(&dyn Themeable, &mut CssClassesBuilder, StrokeParams<'_>),
-        specified: Option<&CssClassPartials>,
         defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
         themeable: &dyn Themeable,
     ) {
         [
@@ -245,9 +245,9 @@ impl CssClassMerger {
                 fn_css_classes,
             } = css_classes_param_groupings;
 
-            let color = attr_value_find(color_keys, specified, defaults);
-            let shade = attr_value_find(shade_keys, specified, defaults);
-            let outline_style = attr_value_find(stroke_style_keys, specified, defaults);
+            let color = attr_value_find(color_keys, defaults, specified);
+            let shade = attr_value_find(shade_keys, defaults, specified);
+            let outline_style = attr_value_find(stroke_style_keys, defaults, specified);
 
             let outline_width = specified
                 .and_then(|partials| partials.get(&ThemeAttr::OutlineWidth))
@@ -298,8 +298,8 @@ impl CssClassMerger {
         css_classes_builder: &mut CssClassesBuilder,
         warnings: &mut ThemeWarnings,
         fn_stroke_classes: fn(&dyn Themeable, &mut CssClassesBuilder, StrokeParams<'_>),
-        specified: Option<&CssClassPartials>,
         defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
         themeable: &dyn Themeable,
     ) {
         [
@@ -315,8 +315,8 @@ impl CssClassMerger {
                 css_classes_builder,
                 warnings,
                 &css_classes_param_groupings,
-                specified,
                 defaults,
+                specified,
                 themeable,
             );
         });
@@ -328,8 +328,8 @@ impl CssClassMerger {
         css_classes_builder: &mut CssClassesBuilder,
         warnings: &mut ThemeWarnings,
         css_classes_param_groupings: &StrokeParamGroupings<StrokeParams<'f1>>,
-        specified: Option<&'f2 CssClassPartials>,
         defaults: Option<&'f2 CssClassPartials>,
+        specified: Option<&'f2 CssClassPartials>,
         themeable: &dyn Themeable,
     ) {
         let StrokeParamGroupings {
@@ -340,9 +340,9 @@ impl CssClassMerger {
             fn_css_classes,
         } = css_classes_param_groupings;
 
-        let color = attr_value_find(color_keys, specified, defaults);
-        let shade = attr_value_find(shade_keys, specified, defaults);
-        let stroke_style = attr_value_find(stroke_style_keys, specified, defaults);
+        let color = attr_value_find(color_keys, defaults, specified);
+        let shade = attr_value_find(shade_keys, defaults, specified);
+        let stroke_style = attr_value_find(stroke_style_keys, defaults, specified);
 
         let stroke_width = specified
             .and_then(|partials| partials.get(&ThemeAttr::StrokeWidth))
@@ -392,8 +392,8 @@ impl CssClassMerger {
         css_classes_builder: &mut CssClassesBuilder,
         warnings: &mut ThemeWarnings,
         fn_fill_classes: fn(&dyn Themeable, &mut CssClassesBuilder, ColorParams<'_>),
-        specified: Option<&CssClassPartials>,
         defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
         themeable: &dyn Themeable,
     ) {
         [
@@ -408,8 +408,8 @@ impl CssClassMerger {
             Self::fill_classes_highlight_state_append(
                 css_classes_param_groupings,
                 warnings,
-                specified,
                 defaults,
+                specified,
                 themeable,
                 css_classes_builder,
             );
@@ -421,8 +421,8 @@ impl CssClassMerger {
     fn fill_classes_highlight_state_append<'f1, 'f2: 'f1>(
         css_classes_param_groupings: ColorParamGroupings<ColorParams<'f1>>,
         warnings: &mut ThemeWarnings,
-        specified: Option<&'f2 CssClassPartials>,
         defaults: Option<&'f2 CssClassPartials>,
+        specified: Option<&'f2 CssClassPartials>,
         themeable: &dyn Themeable,
         css_classes_builder: &mut CssClassesBuilder,
     ) {
@@ -433,8 +433,8 @@ impl CssClassMerger {
             fn_css_classes,
         } = css_classes_param_groupings;
 
-        let color = attr_value_find(color_keys, specified, defaults);
-        let shade = attr_value_find(shade_keys, specified, defaults);
+        let color = attr_value_find(color_keys, defaults, specified);
+        let shade = attr_value_find(shade_keys, defaults, specified);
 
         if let Some(params) = color.zip(shade).map(|(color, shade)| ColorParams {
             highlight_state,
@@ -460,8 +460,8 @@ impl CssClassMerger {
     }
 
     fn cursor_classes(
-        specified: Option<&CssClassPartials>,
         defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
         css_classes_builder: &mut CssClassesBuilder,
     ) {
         specified
@@ -471,8 +471,8 @@ impl CssClassMerger {
     }
 
     fn extra_classes(
-        specified: Option<&CssClassPartials>,
         defaults: Option<&CssClassPartials>,
+        specified: Option<&CssClassPartials>,
         css_classes_builder: &mut CssClassesBuilder,
     ) {
         if let Some(extra) = specified
@@ -500,13 +500,13 @@ impl CssClassMerger {
 /// more specific default is used.
 fn attr_value_find<'attr>(
     attr_keys: &'attr [ThemeAttr],
-    el_class_partials: Option<&'attr CssClassPartials>,
     defaults: Option<&'attr CssClassPartials>,
+    specified: Option<&'attr CssClassPartials>,
 ) -> Option<&'attr str> {
     attr_keys
         .iter()
         .find_map(|attr_key| {
-            el_class_partials
+            specified
                 .and_then(|partials| partials.get(attr_key))
                 .or_else(|| defaults.and_then(|partials| partials.get(attr_key)))
         })

--- a/crate/model/src/theme/css_class_merger.rs
+++ b/crate/model/src/theme/css_class_merger.rs
@@ -117,8 +117,8 @@ impl CssClassMerger {
                 .map(|spacing| css_classes_builder.append(&format!("{spacing_prefix}-{spacing}")));
         });
 
-        Self::cursor_classes(defaults, specified, &mut css_classes_builder);
-        Self::extra_classes(defaults, specified, &mut css_classes_builder);
+        Self::cursor_classes(&mut css_classes_builder, defaults, specified);
+        Self::extra_classes(&mut css_classes_builder, defaults, specified);
 
         let css_classes = css_classes_builder.build();
 
@@ -213,8 +213,8 @@ impl CssClassMerger {
             themeable,
         );
 
-        Self::cursor_classes(defaults, specified, &mut css_classes_builder);
-        Self::extra_classes(defaults, specified, &mut css_classes_builder);
+        Self::cursor_classes(&mut css_classes_builder, defaults, specified);
+        Self::extra_classes(&mut css_classes_builder, defaults, specified);
 
         let css_classes = css_classes_builder.build();
 
@@ -460,9 +460,9 @@ impl CssClassMerger {
     }
 
     fn cursor_classes(
+        css_classes_builder: &mut CssClassesBuilder,
         defaults: Option<&CssClassPartials>,
         specified: Option<&CssClassPartials>,
-        css_classes_builder: &mut CssClassesBuilder,
     ) {
         specified
             .and_then(|partials| partials.get(&ThemeAttr::Cursor))
@@ -471,9 +471,9 @@ impl CssClassMerger {
     }
 
     fn extra_classes(
+        css_classes_builder: &mut CssClassesBuilder,
         defaults: Option<&CssClassPartials>,
         specified: Option<&CssClassPartials>,
-        css_classes_builder: &mut CssClassesBuilder,
     ) {
         if let Some(extra) = specified
             .and_then(|partials| partials.get(&ThemeAttr::Extra))

--- a/crate/model/src/theme/css_classes_and_warnings.rs
+++ b/crate/model/src/theme/css_classes_and_warnings.rs
@@ -1,0 +1,32 @@
+use crate::theme::{CssClasses, ThemeWarnings};
+
+/// `CssClasses` for a node/edge, and warnings detected while computing the CSS
+/// utility classes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CssClassesAndWarnings {
+    /// Whether the element is in the normal, focused, hovered, or active state.
+    pub css_classes: CssClasses,
+    /// Warnings detected while computing CSS utility classes.
+    pub theme_warnings: ThemeWarnings,
+}
+
+impl<'params> CssClassesAndWarnings {
+    /// Returns a new `CssClassesAndWarnings`.
+    pub fn new(css_classes: CssClasses, theme_warnings: ThemeWarnings) -> Self {
+        Self {
+            css_classes,
+            theme_warnings,
+        }
+    }
+
+    /// Returns whether the element is in the normal, focused, hovered, or
+    /// active state.
+    pub fn css_classes(&self) -> &str {
+        &self.css_classes
+    }
+
+    /// Returns warnings detected while computing CSS utility classes.
+    pub fn theme_warnings(&self) -> &ThemeWarnings {
+        &self.theme_warnings
+    }
+}

--- a/crate/model/src/theme/css_classes_and_warnings.rs
+++ b/crate/model/src/theme/css_classes_and_warnings.rs
@@ -10,7 +10,7 @@ pub struct CssClassesAndWarnings {
     pub theme_warnings: ThemeWarnings,
 }
 
-impl<'params> CssClassesAndWarnings {
+impl CssClassesAndWarnings {
     /// Returns a new `CssClassesAndWarnings`.
     pub fn new(css_classes: CssClasses, theme_warnings: ThemeWarnings) -> Self {
         Self {

--- a/crate/model/src/theme/theme_attr.rs
+++ b/crate/model/src/theme/theme_attr.rs
@@ -308,6 +308,35 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ThemeAttr {
+    /// Animation to apply to the item.
+    ///
+    /// This sets the [`animate-*`] class, valid values are `'none'`,
+    /// `'spin'`, `'ping'`, `'pulse'`, `'bounce'`.
+    ///
+    /// Arbitrary values such as `'[stroke-dashoffset-move_2s_linear_infinite]'`
+    /// can be used if an animation such as the following is provided in the
+    /// `InfoGraph::css` key:
+    ///
+    /// ```yaml
+    /// theme:
+    ///   styles:
+    ///     edge_defaults:
+    ///       animate: '[stroke-dashoffset-move_2s_linear_infinite]'
+    ///       shape_color: blue
+    ///       stroke_style: dashed  # shorthand for [&>path]:[stroke-dasharray:3]
+    ///       stroke_width: '[2px]'
+    ///       stroke_shade_normal: '600'
+    ///       fill_shade_normal: '500'
+    ///
+    /// css: >-
+    ///   @keyframes stroke-dashoffset-move {
+    ///     0%   { stroke-dashoffset: 30; }
+    ///     100% { stroke-dashoffset: 0; }
+    ///   }
+    /// ```
+    ///
+    /// [`animate-*`] https://tailwindcss.com/docs/animation
+    Animate,
     /// The [cursor style], e.g. `"pointer"`.
     ///
     /// [cursor style]: https://tailwindcss.com/docs/cursor

--- a/crate/model/src/theme/theme_attr.rs
+++ b/crate/model/src/theme/theme_attr.rs
@@ -478,4 +478,11 @@ pub enum ThemeAttr {
     /// Line/border style when an element is being clicked / pressed, e.g.
     /// `"none"`, `"solid"`, `"dashed"`, `"dotted"`.
     StrokeStyleActive,
+    /// Whether an element is visible.
+    ///
+    /// This sets the [`visibility`] class, valid values are `'visible'`,
+    /// `'invisible'`, `'collapse'`.
+    ///
+    /// [`visibility`] https://tailwindcss.com/docs/visibility
+    Visibility,
 }

--- a/crate/model/src/theme/theme_warnings.rs
+++ b/crate/model/src/theme/theme_warnings.rs
@@ -1,11 +1,13 @@
 use std::ops::{Deref, DerefMut};
 
+use indexmap::IndexSet;
 use serde::{Deserialize, Serialize};
 
-/// Warnings detected while computing CSS utility classes. `Vec<String>`
+/// Warnings detected while computing CSS utility classes. `IndexSet<String>`
 /// newtype.
+// TODO: Store a list of error enum variants, rather than `String`s.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
-pub struct ThemeWarnings(Vec<String>);
+pub struct ThemeWarnings(IndexSet<String>);
 
 impl ThemeWarnings {
     /// Returns a new `ThemeWarnings` list.
@@ -16,17 +18,17 @@ impl ThemeWarnings {
     /// Returns a new `ThemeWarnings` list with the given preallocated
     /// capacity.
     pub fn with_capacity(capacity: usize) -> Self {
-        Self(Vec::with_capacity(capacity))
+        Self(IndexSet::with_capacity(capacity))
     }
 
     /// Returns the underlying list.
-    pub fn into_inner(self) -> Vec<String> {
+    pub fn into_inner(self) -> IndexSet<String> {
         self.0
     }
 }
 
 impl Deref for ThemeWarnings {
-    type Target = Vec<String>;
+    type Target = IndexSet<String>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -39,14 +41,14 @@ impl DerefMut for ThemeWarnings {
     }
 }
 
-impl From<Vec<String>> for ThemeWarnings {
-    fn from(inner: Vec<String>) -> Self {
+impl From<IndexSet<String>> for ThemeWarnings {
+    fn from(inner: IndexSet<String>) -> Self {
         Self(inner)
     }
 }
 
 impl FromIterator<String> for ThemeWarnings {
     fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
-        Self(Vec::from_iter(iter))
+        Self(IndexSet::from_iter(iter))
     }
 }

--- a/crate/model/src/theme/theme_warnings.rs
+++ b/crate/model/src/theme/theme_warnings.rs
@@ -1,0 +1,52 @@
+use std::ops::{Deref, DerefMut};
+
+use serde::{Deserialize, Serialize};
+
+/// Warnings detected while computing CSS utility classes. `Vec<String>`
+/// newtype.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ThemeWarnings(Vec<String>);
+
+impl ThemeWarnings {
+    /// Returns a new `ThemeWarnings` list.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a new `ThemeWarnings` list with the given preallocated
+    /// capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity))
+    }
+
+    /// Returns the underlying list.
+    pub fn into_inner(self) -> Vec<String> {
+        self.0
+    }
+}
+
+impl Deref for ThemeWarnings {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for ThemeWarnings {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<Vec<String>> for ThemeWarnings {
+    fn from(inner: Vec<String>) -> Self {
+        Self(inner)
+    }
+}
+
+impl FromIterator<String> for ThemeWarnings {
+    fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
+        Self(Vec::from_iter(iter))
+    }
+}

--- a/crate/rt/src/into_graphviz_dot_src/info_graph.rs
+++ b/crate/rt/src/into_graphviz_dot_src/info_graph.rs
@@ -17,7 +17,7 @@ use indoc::{formatdoc, writedoc};
 use crate::{InfoGraphDot, IntoGraphvizDotSrc};
 
 /// Hack to get Chrome/Edge to not display black box around focused nodes.
-const OUTLINE_NONE: &'static str = "outline-none";
+const OUTLINE_NONE: &str = "outline-none";
 
 /// Renders a GraphViz Dot diagram with interactive styling.
 ///

--- a/crate/rt/src/into_graphviz_dot_src/info_graph.rs
+++ b/crate/rt/src/into_graphviz_dot_src/info_graph.rs
@@ -16,6 +16,9 @@ use indoc::{formatdoc, writedoc};
 
 use crate::{InfoGraphDot, IntoGraphvizDotSrc};
 
+/// Hack to get Chrome/Edge to not display black box around focused nodes.
+const OUTLINE_NONE: &'static str = "outline-none";
+
 /// Renders a GraphViz Dot diagram with interactive styling.
 ///
 /// This is currently a mashed together implementation. A proper implementation
@@ -486,7 +489,7 @@ fn node_cluster_internal(
                             </tr>
                             {node_desc}
                         </table>>
-                        class = "{node_tailwind_classes}{node_tag_classes}"
+                        class = "{OUTLINE_NONE} {node_tailwind_classes}{node_tag_classes}"
                     ]
                 "#
             )?,
@@ -508,11 +511,11 @@ fn node_cluster_internal(
                         subgraph cluster_{node_id} {{
                             label = <>
                             margin = 0.0
-                            class = ""
+                            class = "{OUTLINE_NONE}"
 
                             {node_id} [
                                 label = ""
-                                class = "{node_tailwind_classes}{node_tag_classes}"
+                                class = "{OUTLINE_NONE} {node_tailwind_classes}{node_tag_classes}"
                                 {margin}
                             ]
                             {node_id}_text [
@@ -554,7 +557,7 @@ fn node_cluster_internal(
                         {node_desc}
                     </table>>
                     style = "filled,rounded"
-                    class = "{node_tailwind_classes}{node_tag_classes}"
+                    class = "{OUTLINE_NONE} {node_tailwind_classes}{node_tag_classes}"
             "#
         )?;
 

--- a/crate/web_components/src/dot_svg.rs
+++ b/crate/web_components/src/dot_svg.rs
@@ -32,7 +32,11 @@ pub async fn dot_svg(
     use std::process::Stdio;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    let DotSrcAndStyles { dot_src, styles: _ } = dot_src_and_styles;
+    let DotSrcAndStyles {
+        dot_src,
+        styles: _,
+        theme_warnings: _,
+    } = dot_src_and_styles;
 
     let mut dot_process = tokio::process::Command::new("dot")
         .arg("-Tsvg")
@@ -298,7 +302,7 @@ pub fn DotSvg(
             if !dot_src_and_styles.dot_src.is_empty() {
                 use std::borrow::Cow;
 
-                let DotSrcAndStyles { dot_src, styles } = dot_src_and_styles;
+                let DotSrcAndStyles { dot_src, styles, theme_warnings: _ } = dot_src_and_styles;
 
                 let (dot_svg, error) = match graphviz_dot_svg(dot_src) {
                     // TODO: need to move tag nodes before all other nodes

--- a/crate/web_components/src/flex_diag.rs
+++ b/crate/web_components/src/flex_diag.rs
@@ -189,7 +189,11 @@ fn el_css_classes(info_graph: &InfoGraph) -> ElCssClasses {
         node_ids: node_id_to_hierarchy.keys().copied().collect::<Vec<_>>(),
         edge_ids: info_graph.edges().keys().collect::<Vec<_>>(),
     };
-    info_graph.theme().el_css_classes(&info_graph_html)
+
+    // TODO: surface theme warnings
+    let (el_css_classes, _theme_warnings) = info_graph.theme().el_css_classes(&info_graph_html);
+
+    el_css_classes
 }
 
 fn divs(flex_divs_ctx: Rc<FlexDivsCtx>, hierarchy: NodeHierarchy) -> impl IntoView {

--- a/playground/src/app/info_graph.rs
+++ b/playground/src/app/info_graph.rs
@@ -230,7 +230,25 @@ pub fn InfoGraph(diagram_only: ReadSignal<bool>) -> impl IntoView {
                     set_error_text.set(None);
                 } else {
                     // TODO: format into a list.
-                    set_error_text.set(Some(theme_warnings.join("\n")));
+                    let theme_warnings_string = {
+                        let capacity = theme_warnings
+                            .iter()
+                            .map(|theme_warning| theme_warning.len())
+                            .sum::<usize>()
+                            + theme_warnings.len();
+                        let mut theme_warnings_string = String::with_capacity(capacity);
+                        let mut theme_warnings_iter = theme_warnings.iter();
+                        if let Some(theme_warning_first) = theme_warnings_iter.next() {
+                            theme_warnings_string.push_str(theme_warning_first);
+                        }
+                        theme_warnings.iter().for_each(|theme_warning| {
+                            theme_warnings_string.push('\n');
+                            theme_warnings_string.push_str(theme_warning);
+                        });
+
+                        theme_warnings_string
+                    };
+                    set_error_text.set(Some(theme_warnings_string));
                 }
                 #[cfg(target_arch = "wasm32")]
                 {

--- a/playground/src/app/info_graph.rs
+++ b/playground/src/app/info_graph.rs
@@ -323,35 +323,6 @@ pub fn InfoGraph(diagram_only: ReadSignal<bool>) -> impl IntoView {
                                 text-xs \
                             "
                         />
-                        <br />
-                        <div
-                            class={
-                                move || {
-                                    let error_text = error_text.get();
-                                    let error_text_empty = error_text
-                                        .as_deref()
-                                        .map(str::is_empty)
-                                        .unwrap_or(true);
-                                    if error_text_empty {
-                                        "hidden"
-                                    } else {
-                                        "
-                                        border
-                                        border-amber-300
-                                        bg-gradient-to-b from-amber-100 to-amber-200
-                                        rounded
-                                        "
-                                    }
-                                }
-                            }
-                            >{
-                                move || {
-                                    let error_text = error_text.get();
-                                    error_text.as_deref()
-                                        .unwrap_or("")
-                                        .to_string()
-                                }
-                            }</div>
                     </div>
 
                     // tab content
@@ -462,8 +433,40 @@ pub fn InfoGraph(diagram_only: ReadSignal<bool>) -> impl IntoView {
                     </div>
                 </div>
             </div>
+            <ErrorText error_text />
             <Disclaimer diagram_only />
         </div>
+    }
+}
+
+#[component]
+pub fn ErrorText(error_text: ReadSignal<Option<String>>) -> impl IntoView {
+    let error_text_classes = move || {
+        let error_text = error_text.get();
+        let error_text_empty = error_text.as_deref().map(str::is_empty).unwrap_or(true);
+        if error_text_empty {
+            "hidden"
+        } else {
+            "
+            border
+            border-amber-300
+            bg-gradient-to-b from-amber-100 to-amber-200
+            rounded
+            "
+        }
+    };
+
+    view! {
+        <div
+            class=error_text_classes
+            >{
+                move || {
+                    let error_text = error_text.get();
+                    error_text.as_deref()
+                        .unwrap_or("")
+                        .to_string()
+                }
+            }</div>
     }
 }
 

--- a/playground/src/app/info_graph_example.yaml
+++ b/playground/src/app/info_graph_example.yaml
@@ -95,7 +95,7 @@ theme:
       stroke_width: '1'
       extra: 'rounded-lg'
     edge_defaults:
-      extra: invisible
+      visibility: invisible
     light: &light
       fill_shade_normal: '100'
       fill_shade_hover: '50'
@@ -173,10 +173,9 @@ common_styles: # not part of `info_graph`, but it ignores unknown keys
     stroke_width: '[2px]'
     stroke_shade_normal: '600'
     fill_shade_normal: '500'
+    visibility: visible
     extra: >-
       [&>path]:animate-[stroke-dashoffset-move_2s_linear_infinite]
-      [&>path]:visible
-      [&>polygon]:visible
 
 
 # We always use the `focus` pseudo class.
@@ -194,9 +193,7 @@ tag_styles_focus:
       <<: *selected_outline
     edge_defaults:
       <<: *selected_outline
-      extra: >-
-        [&>path]:visible
-        [&>polygon]:visible
+      visibility: visible
 
   tag_step_2:
     edge_defaults:
@@ -213,19 +210,17 @@ tag_styles_focus:
       shape_color: violet
       stroke_style: "dasharray:0,80,12,2,4,2,2,2,1,2,1,120"
       stroke_width: '[1px]'
+      visibility: visible
       extra: >-
         [&>path]:animate-[stroke-dashoffset-move-request_2s_linear_infinite]
-        [&>path]:visible
-        [&>polygon]:visible
     github_app_zip__app_download_response:
       <<: *edge_blue_animated
       shape_color: purple
       stroke_style: "dasharray:0,120,1,2,1,2,2,2,4,2,8,2,20,80"
       stroke_width: '[2px]'
+      visibility: visible
       extra: >-
         [&>path]:animate-[stroke-dashoffset-move-response_2s_linear_infinite]
-        [&>path]:visible
-        [&>polygon]:visible
 
   tag_step_3:
     node_defaults: *node_completed

--- a/playground/src/app/info_graph_example.yaml
+++ b/playground/src/app/info_graph_example.yaml
@@ -142,7 +142,9 @@ tag_items:
   tag_step_4: [iam_policy, iam_role, instance_profile, github_app_zip, app_download, app_download__s3_object, s3_object, app_extract, app_download__app_extract]
   tag_step_5: [iam_policy, iam_role, instance_profile, github_app_zip, app_download, app_download__s3_object, s3_object, app_extract]
 
-common_styles: # not part of `info_graph`, but it ignores unknown keys
+# Not part of `info_graph`, but for deduplication, we can use our own keys.
+# Unknown keys are ignored during deserialization
+common_styles:
   selected_outline: &selected_outline
     outline_color: red
     outline_style: dashed
@@ -151,6 +153,7 @@ common_styles: # not part of `info_graph`, but it ignores unknown keys
 
   node_blue_progress: &node_blue_progress
     <<: *selected_outline
+    animate: '[ellipse-spin_1.5s_linear_infinite]'
     shape_color: blue
     stroke_shade: '600'
     stroke_style: "dasharray:0.5,3,0.5,3,0.5,3,0.5,3,6,3,12,30"
@@ -158,7 +161,6 @@ common_styles: # not part of `info_graph`, but it ignores unknown keys
     fill_shade: '200'
     extra: |-
       [&>ellipse]:[stroke-linecap:round]
-      [&>ellipse]:animate-[ellipse-spin_1.5s_linear_infinite]
 
   node_completed: &node_completed
     shape_color: green
@@ -168,14 +170,13 @@ common_styles: # not part of `info_graph`, but it ignores unknown keys
     fill_shade: '200'
 
   edge_blue_animated: &edge_blue_animated
+    animate: '[stroke-dashoffset-move_2s_linear_infinite]'
     shape_color: blue
     stroke_style: dashed  # shorthand for [&>path]:[stroke-dasharray:3]
     stroke_width: '[2px]'
     stroke_shade_normal: '600'
     fill_shade_normal: '500'
     visibility: visible
-    extra: >-
-      [&>path]:animate-[stroke-dashoffset-move_2s_linear_infinite]
 
 
 # We always use the `focus` pseudo class.
@@ -191,13 +192,8 @@ tag_styles_focus:
     instance_profile: *node_blue_progress
     node_defaults:
       <<: *selected_outline
-    edge_defaults:
-      <<: *selected_outline
-      visibility: visible
 
   tag_step_2:
-    edge_defaults:
-      <<: *selected_outline
     iam_policy: *node_completed
     iam_role: *node_completed
     instance_profile: *node_completed
@@ -207,20 +203,18 @@ tag_styles_focus:
 
     github_app_zip__app_download_request:
       <<: *edge_blue_animated
+      animate: '[stroke-dashoffset-move-request_2s_linear_infinite]'
       shape_color: violet
       stroke_style: "dasharray:0,80,12,2,4,2,2,2,1,2,1,120"
       stroke_width: '[1px]'
       visibility: visible
-      extra: >-
-        [&>path]:animate-[stroke-dashoffset-move-request_2s_linear_infinite]
     github_app_zip__app_download_response:
       <<: *edge_blue_animated
+      animate: '[stroke-dashoffset-move-response_2s_linear_infinite]'
       shape_color: purple
       stroke_style: "dasharray:0,120,1,2,1,2,2,2,4,2,8,2,20,80"
       stroke_width: '[2px]'
       visibility: visible
-      extra: >-
-        [&>path]:animate-[stroke-dashoffset-move-response_2s_linear_infinite]
 
   tag_step_3:
     node_defaults: *node_completed

--- a/playground/src/app/text_editor.rs
+++ b/playground/src/app/text_editor.rs
@@ -156,6 +156,7 @@ impl EditorState {
     }
 
     #[cfg(target_arch = "wasm32")]
+    #[allow(dead_code)] // Not used currently, but was attempted in `create_effect` above.
     pub fn set_value(&self, value: &str) {
         if let Some(text_model) = self
             .code_editor

--- a/workspace_tests/src/model/theme.rs
+++ b/workspace_tests/src/model/theme.rs
@@ -68,7 +68,7 @@ fn tag_theme_merge_resolves_node_outline() {
     };
     let themeable = &info_graph_dot;
 
-    let tag_el_css_classes =
+    let (tag_el_css_classes, _theme_warnings) =
         tag_theme.tag_el_css_classes(themeable, &diagram_theme, &tag_id!("tag_step_1"));
 
     let css_classes = tag_el_css_classes.get(test_node_id.as_str());


### PR DESCRIPTION
* Add `ThemeAttr::Animate` to support setting [`animation`].
* Add `ThemeAttr::Visibility` to support setting [`visibility`].
* Fix black outline shown on focused nodes in Chrome / Edge.
* Show feedback to user when stroke / outline / fill class partials are not all specified.

[`animation`]: https://tailwindcss.com/docs/animation
[`visibility`]: https://tailwindcss.com/docs/visibility
