### PR TITLE
Support `margins`, `margin_cluster_default`, and `margin_node_default`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## unreleased
 
+* Support `margins` in `GraphvizAttrs`.
+* Support `margin_cluster_default` in `GraphvizAttrs`.
+* Support `margin_node_default` in `GraphvizAttrs`.
 * Support `node_width_default` in `GraphvizAttrs`.
 * Support `node_widths` in `GraphvizAttrs`.
 * Support `node_height_default` in `GraphvizAttrs`.

--- a/crate/model/src/common/graphviz_attrs.rs
+++ b/crate/model/src/common/graphviz_attrs.rs
@@ -1,17 +1,22 @@
 use serde::{Deserialize, Serialize};
 
 pub use self::{
-    edge_constraints::EdgeConstraints, edge_dir::EdgeDir, edge_dirs::EdgeDirs,
-    edge_minlens::EdgeMinlens, fixed_size::FixedSize, node_heights::NodeHeights,
-    node_widths::NodeWidths, pack_mode::PackMode, pack_mode_flag::PackModeFlag, splines::Splines,
+    cluster_margin::ClusterMargin, edge_constraints::EdgeConstraints, edge_dir::EdgeDir,
+    edge_dirs::EdgeDirs, edge_minlens::EdgeMinlens, fixed_size::FixedSize, margin::Margin,
+    margins::Margins, node_heights::NodeHeights, node_margin::NodeMargin, node_widths::NodeWidths,
+    pack_mode::PackMode, pack_mode_flag::PackModeFlag, splines::Splines,
 };
 
+mod cluster_margin;
 mod edge_constraints;
 mod edge_dir;
 mod edge_dirs;
 mod edge_minlens;
 mod fixed_size;
+mod margin;
+mod margins;
 mod node_heights;
+mod node_margin;
 mod node_widths;
 mod pack_mode;
 mod pack_mode_flag;
@@ -69,6 +74,24 @@ pub struct GraphvizAttrs {
     ///
     /// [`minlen`]: https://graphviz.org/docs/attrs/minlen/
     pub edge_minlens: EdgeMinlens,
+    /// The default value for each node's [`margin`], defaults to `0.11,0.055`.
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub margin_cluster_default: ClusterMargin,
+    /// The default value for each cluster's [`margin`], defaults to `8.0`.
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub margin_node_default: NodeMargin,
+    /// Each node or cluster's [`margin`].
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub margins: Margins,
     /// Minimum / initial [`width`] for nodes, defaults to `0.3`.
     ///
     /// If `fixedsize` is true, this will be the exact / maximum width for
@@ -194,6 +217,37 @@ impl GraphvizAttrs {
     /// [`minlen`]: https://graphviz.org/docs/attrs/minlen/
     pub fn with_edge_minlens(mut self, edge_minlens: EdgeMinlens) -> Self {
         self.edge_minlens = edge_minlens;
+        self
+    }
+
+    /// Sets the default value for each node's [`margin`], defaults to
+    /// `0.11,0.055`.
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn with_margin_cluster_default(mut self, margin_cluster_default: ClusterMargin) -> Self {
+        self.margin_cluster_default = margin_cluster_default;
+        self
+    }
+
+    /// Sets the default value for each cluster's [`margin`], defaults to `8.0`.
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn with_margin_node_default(mut self, margin_node_default: NodeMargin) -> Self {
+        self.margin_node_default = margin_node_default;
+        self
+    }
+
+    /// Sets each node or cluster's [`margin`].
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn with_margins(mut self, margins: Margins) -> Self {
+        self.margins = margins;
         self
     }
 
@@ -323,6 +377,33 @@ impl GraphvizAttrs {
         &self.edge_minlens
     }
 
+    /// Returns the default value for each node's [`margin`].
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn margin_cluster_default(&self) -> ClusterMargin {
+        self.margin_cluster_default
+    }
+
+    /// Returns the default value for each cluster's [`margin`].
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn margin_node_default(&self) -> NodeMargin {
+        self.margin_node_default
+    }
+
+    /// Returns each node or cluster's [`margin`].
+    ///
+    /// May be a single float, or two floats separated by a comma.
+    ///
+    /// [`margin`]: https://graphviz.org/docs/attrs/margin/
+    pub fn margins(&self) -> &Margins {
+        &self.margins
+    }
+
     /// Returns the minimum / initial [`width`] for nodes.
     ///
     /// If `fixedsize` is true, this will be the exact / maximum width for
@@ -385,6 +466,9 @@ impl Default for GraphvizAttrs {
             edge_dirs: EdgeDirs::default(),
             edge_minlen_default: 2,
             edge_minlens: EdgeMinlens::default(),
+            margin_cluster_default: ClusterMargin::default(),
+            margin_node_default: NodeMargin::default(),
+            margins: Margins::default(),
             node_width_default: 0.3,
             node_widths: NodeWidths::default(),
             node_height_default: 0.1,

--- a/crate/model/src/common/graphviz_attrs/cluster_margin.rs
+++ b/crate/model/src/common/graphviz_attrs/cluster_margin.rs
@@ -1,0 +1,61 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::graphviz_attrs::Margin;
+
+/// A node [`margin`], which specifies the space between the nodes in the
+/// cluster and the cluster bounding box.
+///
+/// Defaults to `Margin::Same(8.0)`; Graphviz default: `8.0`.
+///
+/// May be a single float, or two floats separated by a comma.
+///
+/// [`margin`]: https://graphviz.org/docs/attrs/margin/
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ClusterMargin(pub Margin);
+
+impl ClusterMargin {
+    /// Returns a new `ClusterMargin`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the inner `Margin`.
+    pub fn into_inner(self) -> Margin {
+        self.0
+    }
+}
+
+impl Default for ClusterMargin {
+    fn default() -> Self {
+        Self(Margin::Same(8.0))
+    }
+}
+
+impl From<Margin> for ClusterMargin {
+    fn from(margin: Margin) -> Self {
+        Self(margin)
+    }
+}
+
+impl std::ops::DerefMut for ClusterMargin {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::ops::Deref for ClusterMargin {
+    type Target = Margin;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for ClusterMargin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crate/model/src/common/graphviz_attrs/margin.rs
+++ b/crate/model/src/common/graphviz_attrs/margin.rs
@@ -1,0 +1,78 @@
+use std::{fmt, fmt::Display, str::FromStr};
+
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+
+/// Node or cluster [`margin`]s.
+///
+/// May be a single float, or two floats separated by a comma.
+///
+/// [`margin`]: https://graphviz.org/docs/attrs/margin/
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Margin {
+    /// Margins on both left/right and top/bottom are the same.
+    Same(f64),
+    /// Margins for left/right are different to top/bottom.
+    Different(f64, f64),
+}
+
+impl FromStr for Margin {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.split_once(',') {
+            Some((margin_x, margin_y)) => {
+                let margin_x = margin_x.parse::<f64>().map_err(|_e| {
+                    format!(
+                        "Failed to parse `{margin_x}` as a margin. \
+                        Please use a floating point number such as 0.5."
+                    )
+                })?;
+                let margin_y = margin_y.parse::<f64>().map_err(|_e| {
+                    format!(
+                        "Failed to parse `{margin_y}` as a margin. \
+                        Please use a floating point number such as 0.5."
+                    )
+                })?;
+
+                Ok(Self::Different(margin_x, margin_y))
+            }
+            None => {
+                let margin = s.parse::<f64>().map_err(|_e| {
+                    format!(
+                        "Failed to parse `{s}` as a margin. \
+                        Please use a floating point number such as 0.5."
+                    )
+                })?;
+                Ok(Self::Same(margin))
+            }
+        }
+    }
+}
+
+impl Display for Margin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Margin::Same(margin) => margin.fmt(f),
+            Margin::Different(margin_x, margin_y) => write!(f, "{margin_x},{margin_y}"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Margin {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
+    }
+}
+
+impl Serialize for Margin {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}

--- a/crate/model/src/common/graphviz_attrs/margins.rs
+++ b/crate/model/src/common/graphviz_attrs/margins.rs
@@ -1,0 +1,64 @@
+use std::ops::{Deref, DerefMut};
+
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::common::{graphviz_attrs::Margin, NodeId};
+
+/// GraphViz node or cluster margins. `IndexMap<NodeId, Margin>` newtype.
+///
+/// This is only used for GraphViz dot graphs, which sets the [`margin`]
+/// attribute for the node / cluster.
+///
+/// If this is unset, nodes will use the default [`NodeMargin`], and clusters
+/// will use the default [`ClusterMargin`].
+///
+/// [`margin`]: https://graphviz.org/docs/attrs/margin/
+/// [`NodeMargin`]: crate::common::graphviz_attrs::NodeMargin
+/// [`ClusterMargin`]: crate::common::graphviz_attrs::ClusterMargin
+#[derive(Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+pub struct Margins(IndexMap<NodeId, Margin>);
+
+impl Margins {
+    /// Returns a new `Margins` map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a new `Margins` map with the given preallocated
+    /// capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(IndexMap::with_capacity(capacity))
+    }
+
+    /// Returns the underlying map.
+    pub fn into_inner(self) -> IndexMap<NodeId, Margin> {
+        self.0
+    }
+}
+
+impl Deref for Margins {
+    type Target = IndexMap<NodeId, Margin>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Margins {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl From<IndexMap<NodeId, Margin>> for Margins {
+    fn from(inner: IndexMap<NodeId, Margin>) -> Self {
+        Self(inner)
+    }
+}
+
+impl FromIterator<(NodeId, Margin)> for Margins {
+    fn from_iter<I: IntoIterator<Item = (NodeId, Margin)>>(iter: I) -> Self {
+        Self(IndexMap::from_iter(iter))
+    }
+}

--- a/crate/model/src/common/graphviz_attrs/node_margin.rs
+++ b/crate/model/src/common/graphviz_attrs/node_margin.rs
@@ -1,0 +1,60 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::common::graphviz_attrs::Margin;
+
+/// A node [`margin`], which specifies space left around the node's label.
+///
+/// Defaults to `Margin::Different(0.04, 0.04)`; Graphviz default: `0.11,0.055`.
+///
+/// May be a single float, or two floats separated by a comma.
+///
+/// [`margin`]: https://graphviz.org/docs/attrs/margin/
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct NodeMargin(pub Margin);
+
+impl NodeMargin {
+    /// Returns a new `NodeMargin`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the inner `Margin`.
+    pub fn into_inner(self) -> Margin {
+        self.0
+    }
+}
+
+impl Default for NodeMargin {
+    fn default() -> Self {
+        Self(Margin::Different(0.11, 0.055))
+    }
+}
+
+impl From<Margin> for NodeMargin {
+    fn from(margin: Margin) -> Self {
+        Self(margin)
+    }
+}
+
+impl std::ops::DerefMut for NodeMargin {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl std::ops::Deref for NodeMargin {
+    type Target = Margin;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Display for NodeMargin {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crate/model/src/common/graphviz_dot_theme.rs
+++ b/crate/model/src/common/graphviz_dot_theme.rs
@@ -7,18 +7,6 @@ pub struct GraphvizDotTheme {
     //
     // <https://graphviz.org/docs/nodes/>
     pub node_text_color: &'static str,
-    /// Left and right margin in inches.
-    ///
-    /// Default: `0.04`.
-    ///
-    /// Graphviz default: `0.11`.
-    pub node_margin_x: f64,
-    /// Top and bottom margin in inches.
-    ///
-    /// Default: `0.04`.
-    ///
-    /// Graphviz default: `0.055`.
-    pub node_margin_y: f64,
     pub plain_text_color: &'static str,
     pub emoji_point_size: u32,
     /// Default font point size for node labels.
@@ -55,16 +43,6 @@ impl GraphvizDotTheme {
 
     pub fn with_node_text_color(mut self, node_text_color: &'static str) -> Self {
         self.node_text_color = node_text_color;
-        self
-    }
-
-    pub fn with_node_margin_x(mut self, node_margin_x: f64) -> Self {
-        self.node_margin_x = node_margin_x;
-        self
-    }
-
-    pub fn with_node_margin_y(mut self, node_margin_y: f64) -> Self {
-        self.node_margin_y = node_margin_y;
         self
     }
 
@@ -126,14 +104,6 @@ impl GraphvizDotTheme {
         self.node_text_color
     }
 
-    pub fn node_margin_x(&self) -> f64 {
-        self.node_margin_x
-    }
-
-    pub fn node_margin_y(&self) -> f64 {
-        self.node_margin_y
-    }
-
     pub fn plain_text_color(&self) -> &str {
         self.plain_text_color
     }
@@ -180,8 +150,6 @@ impl Default for GraphvizDotTheme {
         Self {
             edge_color: "#333333",
             node_text_color: "#111111",
-            node_margin_x: 0.04,
-            node_margin_y: 0.04,
             plain_text_color: "#222222",
             emoji_point_size: 14,
             node_point_size: 10,


### PR DESCRIPTION
Example:

![item_trait](https://github.com/user-attachments/assets/b88bfb07-3362-4366-bfcb-7def1fe464fa)

[source](https://azriel.im/dot_ix/#src=LQhQAsEsFMCcENYGNwE8BcoAEXIBdoBbTHHfIgfQHNYB7AVwAcKBGE0nAYlwBN0sA3gF9sHLNwDO0PE37DRHSXngEK0AB7xCjADbQ5IseKx5YqChOWqk9WLGgA7PAYWlLK6BRt3HzwYbF3VSpaeB0XI25TcyDPELCIwKtPHkgAMzSXV3JCajomCgAmdg5Yrz14B0TFLHhGXXMUaCQAa2rSbjqGih4zdpwunQx-VzInOHgkPEhaBwksh1oeTwctaHnRHP4AIgBJAkJtzb4jU9JtyB4jnCkZRn4zjm3bpmuTMwtkr1t7Jx3AXg3ALM77xiX28vzwbzK4N8D3OQKw0J+vje0U+HmooXCT0APBuAev2QejglioV94tjTtt8YiySTRGVUhk4WJtv9ADy7NIxjLSpIxSAqVUpgD4NwCfu5zrAK3oNGuBmm1Kf9AN07tXqQy8staUtV5l6wzOrOV0p6Zi1DWZjwNKoavNUGi0un0LP+gF2d8WeO3aPRvSDjBBTGZzc1YKmABH3cL7JtNZhIjqBoDwqOt2Dk8gxmCwKBQUzQ00V+ABtJE+JwAGlwB1TBUKAF1QKAaHVwAA3SAALwoKlMGxwi2WFAA7pc8OAetA0vB6Do-CwAHQAdlEvc8ssgVHAeFH48nfgADDOACyiBAOFpSe5YPc7wqiQiIKg+7ukLZYQqX7IVnMFNgXmc79+UT9mGKH8-1AYciH0ek8FQPRHxwKAeGWQUADIEKQ0YsBbCRIAAI0gHR8GGH0sNwvQ6w4RgwkdZDKLIow0nwnQLHAeA+0WWBb2xAByABWHcuIwhidCYiQWL7cBaCbOB+F4-jBMY5jWM8NJaBseYsC4lgdzk+iFNEpSO39KSZK0nSkjoFpPH0tjaA4hINP3bSBKMSwLKssTl0k6SNIAZicjDXNoSzFL7SNIGMjS+LM0pTCCqzoL0fgeFoPACB4AKWMYTwkFoHRbP4HCdHoaByNIAi1z8ZDyvXeThJClZbM4kz-N0urrM8qTYBkvjnLEISRI8igVLU5rotIfr6sM6YIs0lrzLiyb2Kahy5pitzJokzqZL8sabli4L2qm8LHVk3bEUy7LcvyrBCuK0qeyWFIxwnKd1IAKmqvB-2ILA3tokrvsrdN+DetDHEBwC81+sGHAh-J00zbN4ah0HLnQoA)